### PR TITLE
Align with DBus terminology

### DIFF
--- a/halinuxcompanion/dbus.py
+++ b/halinuxcompanion/dbus.py
@@ -28,23 +28,23 @@ SIGNALS = {
 INTERFACES = {
     "org.freedesktop.login1.Manager": {
         "type": "system",
-        "interface": "org.freedesktop.login1",
+        "service": "org.freedesktop.login1",
         "path": "/org/freedesktop/login1",
-        "proxy_interface": "org.freedesktop.login1.Manager"
+        "interface": "org.freedesktop.login1.Manager",
     },
     "org.freedesktop.Notifications": {
         "type": "session",
-        "interface": "org.freedesktop.Notifications",
+        "service": "org.freedesktop.Notifications",
         "path": "/org/freedesktop/Notifications",
-        "proxy_interface": "org.freedesktop.Notifications"
+        "interface": "org.freedesktop.Notifications",
     },
 }
 
 
-async def get_interface(bus, interface, path, proxy_interface):
-    introspection = await bus.introspect(interface, path)
-    proxy = bus.get_proxy_object(interface, path, introspection)
-    return proxy.get_interface(proxy_interface)
+async def get_interface(bus, service, path, interface) -> ProxyInterface:
+    introspection = await bus.introspect(service, path)
+    proxy = bus.get_proxy_object(service, path, introspection)
+    return proxy.get_interface(interface)
 
 
 class Dbus:
@@ -58,14 +58,14 @@ class Dbus:
 
     async def get_interface(self, name: str) -> ProxyInterface:
         i = INTERFACES[name]
-        type, interface, path, proxy_interface = i["type"], i["interface"], i["path"], i["proxy_interface"]
+        bus_type, service, path, interface = i["type"], i["service"], i["path"], i["interface"]
         iface = self.interfaces.get(name)
         if iface is None:
-            if type == "system":
+            if bus_type == "system":
                 bus = self.system
             else:
                 bus = self.session
-            iface = await get_interface(bus, interface, path, proxy_interface)
+            iface = await get_interface(bus, service, path, interface)
             self.interfaces[name] = iface
 
         return iface

--- a/halinuxcompanion/dbus.py
+++ b/halinuxcompanion/dbus.py
@@ -7,22 +7,18 @@ logger = logging.getLogger(__name__)
 
 SIGNALS = {
     "session.notification_on_action_invoked": {
-        "type": "session",
         "name": "on_action_invoked",
         "interface": "org.freedesktop.Notifications",
     },
     "session.notification_on_notification_closed": {
-        "type": "session",
         "name": "on_notification_closed",
         "interface": "org.freedesktop.Notifications",
     },
     "system.login_on_prepare_for_sleep": {
-        "type": "system",
         "name": "on_prepare_for_sleep",
         "interface": "org.freedesktop.login1.Manager",
     },
     "system.login_on_prepare_for_shutdown": {
-        "type": "system",
         "name": "on_prepare_for_shutdown",
         "interface": "org.freedesktop.login1.Manager",
     },


### PR DESCRIPTION
I spent some time trying to register a new listener and while doing so I realized that even when I had all the DBus info that I needed, it was not so straightforward to infer how to make it fit into `SIGNALS` and `INTERFACES` here.
After spending some time with the code, the [`dbus-next` docs](https://python-dbus-next.readthedocs.io/en/latest/) and getting everything to work, I thought that things would be made much easier if we changed the names here a little bit to match the DBus terminology:
* What was defined under `interface` is really the Service name.
* What was named the `proxy_interface` is really just the name of the Interface.

It's clear to see why these two are confusing: Both use the _reverse domain name notation_ (e.g. `org.freedesktop.login1`), and services often expose at their top level an interface with the same name as the service itself (as with `org.freedesktop.Notifications`).


Bottom line, these two commits make mostly cosmetic changes to `dbus.py`, but should help other contributors find their arms and legs more easily.