### PR TITLE
Add 'idle' attribute to the Status sensor

### DIFF
--- a/halinuxcompanion/dbus.py
+++ b/halinuxcompanion/dbus.py
@@ -14,6 +14,10 @@ SIGNALS = {
         "name": "on_notification_closed",
         "interface": "org.freedesktop.Notifications",
     },
+    "session.screensaver_on_active_changed": {
+        "name": "on_active_changed",
+        "interface": "org.freedesktop.ScreenSaver",
+    },
     "system.login_on_prepare_for_sleep": {
         "name": "on_prepare_for_sleep",
         "interface": "org.freedesktop.login1.Manager",
@@ -31,6 +35,12 @@ INTERFACES = {
         "service": "org.freedesktop.login1",
         "path": "/org/freedesktop/login1",
         "interface": "org.freedesktop.login1.Manager",
+    },
+    "org.freedesktop.ScreenSaver": {
+        "type": "session",
+        "service": "org.freedesktop.ScreenSaver",
+        "path": "/org/freedesktop/ScreenSaver",
+        "interface": "org.freedesktop.ScreenSaver",
     },
     "org.freedesktop.Notifications": {
         "type": "session",

--- a/halinuxcompanion/sensors/status.py
+++ b/halinuxcompanion/sensors/status.py
@@ -18,8 +18,8 @@ Status.icon = "mdi:cpu-64-bit"
 Status.state = True
 Status.attributes = {"reason": "power_on"}
 
-sleep = {True: {"reason": "sleep"}, False: {"reason": "wake"}}
-shutdown = {True: {"reason": "power_off"}, False: {"reason": "power_on"}}
+SLEEP = {True: {"reason": "sleep"}, False: {"reason": "wake"}}
+SHUTDOWN = {True: {"reason": "power_off"}, False: {"reason": "power_on"}}
 
 
 async def on_prepare_for_sleep(self, v):
@@ -29,17 +29,17 @@ async def on_prepare_for_sleep(self, v):
     :param v: True if going to sleep, False if waking up from it
     """
     self.state = not v
-    self.attributes = sleep[v]
+    self.attributes = SLEEP[v]
 
 
 async def on_prepare_for_shutdown(self, v):
     """Handler for system shutdown/reboot.
     https://www.freedesktop.org/software/systemd/man/org.freedesktop.login1.html
 
-    :param v: True if shuting down, False if powering on.
+    :param v: True if shutting down, False if powering on.
     """
     self.state = not v
-    self.attributes = shutdown[v]
+    self.attributes = SHUTDOWN[v]
 
 
 def updater(self):

--- a/halinuxcompanion/sensors/status.py
+++ b/halinuxcompanion/sensors/status.py
@@ -7,18 +7,8 @@ import logging
 
 logger = logging.getLogger(__name__)
 
-load_average: bool = False
-
 Status = Sensor()
 Status.config_name = "status"
-Status.attributes = {
-    "cpu_count": psutil.cpu_count(logical=False),
-    "cpu_logical_count": psutil.cpu_count(),
-}
-
-if os.name == "posix":
-    load_average = True
-
 Status.type = "binary_sensor"
 Status.device_class = "power"
 Status.name = "Status"

--- a/halinuxcompanion/sensors/status.py
+++ b/halinuxcompanion/sensors/status.py
@@ -16,8 +16,9 @@ Status.unique_id = "status"
 Status.icon = "mdi:cpu-64-bit"
 
 Status.state = True
-Status.attributes = {"reason": "power_on"}
+Status.attributes = {"reason": "power_on", "idle": "unknown"}
 
+IDLE = {True: {"idle": "true"}, False: {"idle": "false"}}
 SLEEP = {True: {"reason": "sleep"}, False: {"reason": "wake"}}
 SHUTDOWN = {True: {"reason": "power_off"}, False: {"reason": "power_on"}}
 
@@ -42,6 +43,11 @@ async def on_prepare_for_shutdown(self, v):
     self.attributes = SHUTDOWN[v]
 
 
+async def screensaver_on_active_changed(self, v):
+    """Handler for session screensaver status changes."""
+    self.attributes.update(IDLE[v])
+
+
 def updater(self):
     # TODO: If computer is still on after "sleep", it should set to on
     self
@@ -52,4 +58,5 @@ Status.updater = MethodType(updater, Status)
 Status.signals = {
     "system.login_on_prepare_for_sleep": on_prepare_for_sleep,
     "system.login_on_prepare_for_shutdown": on_prepare_for_shutdown,
+    "session.screensaver_on_active_changed": screensaver_on_active_changed,
 }


### PR DESCRIPTION
This PR adds an "idle" attribute to the Status sensor.
It doesn't change the overall state of the sensor, but provides a hint as to whether the machine is currently in active use versus just powered on and not in sleep mode.

I tried different signals from `org.freedesktop.login1` (hence the multiple parameters support - #11), but eventually `org.freedesktop.ScreenSaver` events were the most reliable on my machine.

Tested on: Fedora KDE 35
**Any help testing this on other Linux flavors would be greatly appreciated.**