### PR TITLE
also listen for org.gnome.ScreenSaver to update 'idle'

### DIFF
--- a/halinuxcompanion/api.py
+++ b/halinuxcompanion/api.py
@@ -2,14 +2,14 @@ from .companion import Companion
 
 import logging
 from aiohttp import (web, ClientSession, ClientResponse)
-from typing import Union
+from typing import Optional
 
 logger = logging.getLogger(__name__)
 
 SC_INVALID_JSON = 400
 SC_MOBILE_COMPONENT_NOT_LOADED = 404
 SC_INTEGRATION_DELETED = 410
-SESSION: Union[ClientSession, None] = None
+SESSION: Optional[ClientSession] = None
 
 
 class API:

--- a/halinuxcompanion/dbus.py
+++ b/halinuxcompanion/dbus.py
@@ -1,7 +1,7 @@
 from dbus_next.aio import MessageBus, ProxyInterface
 from dbus_next import BusType
 from dbus_next.errors import DBusError
-from typing import Callable, Union
+from typing import Callable, Optional
 import logging
 
 logger = logging.getLogger(__name__)
@@ -62,7 +62,7 @@ INTERFACES = {
 }
 
 
-async def get_interface(bus, service, path, interface) -> Union[ProxyInterface, None]:
+async def get_interface(bus, service, path, interface) -> Optional[ProxyInterface]:
     try:
         introspection = await bus.introspect(service, path)
         proxy = bus.get_proxy_object(service, path, introspection)
@@ -80,7 +80,7 @@ class Dbus:
         self.system = await MessageBus(bus_type=BusType.SYSTEM).connect()
         self.session = await MessageBus(bus_type=BusType.SESSION).connect()
 
-    async def get_interface(self, name: str) -> Union[ProxyInterface, None]:
+    async def get_interface(self, name: str) -> Optional[ProxyInterface]:
         i = INTERFACES[name]
         bus_type, service, path, interface = i["type"], i["service"], i["path"], i["interface"]
         iface = self.interfaces.get(name)

--- a/halinuxcompanion/dbus.py
+++ b/halinuxcompanion/dbus.py
@@ -18,6 +18,10 @@ SIGNALS = {
         "name": "on_active_changed",
         "interface": "org.freedesktop.ScreenSaver",
     },
+    "session.gnome_screensaver_on_active_changed": {
+        "name": "on_active_changed",
+        "interface": "org.gnome.ScreenSaver",
+    },
     "system.login_on_prepare_for_sleep": {
         "name": "on_prepare_for_sleep",
         "interface": "org.freedesktop.login1.Manager",
@@ -41,6 +45,12 @@ INTERFACES = {
         "service": "org.freedesktop.ScreenSaver",
         "path": "/org/freedesktop/ScreenSaver",
         "interface": "org.freedesktop.ScreenSaver",
+    },
+    "org.gnome.ScreenSaver": {
+        "type": "session",
+        "service": "org.gnome.ScreenSaver",
+        "path": "/org/gnome/ScreenSaver",
+        "interface": "org.gnome.ScreenSaver",
     },
     "org.freedesktop.Notifications": {
         "type": "session",

--- a/halinuxcompanion/dbus.py
+++ b/halinuxcompanion/dbus.py
@@ -1,6 +1,7 @@
 from dbus_next.aio import MessageBus, ProxyInterface
 from dbus_next import BusType
-from typing import Callable
+from dbus_next.errors import DBusError
+from typing import Callable, Union
 import logging
 
 logger = logging.getLogger(__name__)
@@ -61,10 +62,13 @@ INTERFACES = {
 }
 
 
-async def get_interface(bus, service, path, interface) -> ProxyInterface:
-    introspection = await bus.introspect(service, path)
-    proxy = bus.get_proxy_object(service, path, introspection)
-    return proxy.get_interface(interface)
+async def get_interface(bus, service, path, interface) -> Union[ProxyInterface, None]:
+    try:
+        introspection = await bus.introspect(service, path)
+        proxy = bus.get_proxy_object(service, path, introspection)
+        return proxy.get_interface(interface)
+    except DBusError:
+        return None
 
 
 class Dbus:
@@ -76,7 +80,7 @@ class Dbus:
         self.system = await MessageBus(bus_type=BusType.SYSTEM).connect()
         self.session = await MessageBus(bus_type=BusType.SESSION).connect()
 
-    async def get_interface(self, name: str) -> ProxyInterface:
+    async def get_interface(self, name: str) -> Union[ProxyInterface, None]:
         i = INTERFACES[name]
         bus_type, service, path, interface = i["type"], i["service"], i["path"], i["interface"]
         iface = self.interfaces.get(name)
@@ -86,7 +90,8 @@ class Dbus:
             else:
                 bus = self.session
             iface = await get_interface(bus, service, path, interface)
-            self.interfaces[name] = iface
+            if iface is not None:
+                self.interfaces[name] = iface
 
         return iface
 
@@ -94,6 +99,9 @@ class Dbus:
         """Register a signal handler"""
         iface_name, signal_name = SIGNALS[signal_alias]["interface"], SIGNALS[signal_alias]["name"]
         iface = await self.get_interface(iface_name)
-        getattr(iface, signal_name)(callback)
-        logger.info("Registered signal callback for interface:%s, signal:%s", iface_name, signal_name)
-        SIGNALS["subscribed"].append((signal_alias, callback))
+        if iface is not None:
+            getattr(iface, signal_name)(callback)
+            logger.info("Registered signal callback for interface:%s, signal:%s", iface_name, signal_name)
+            SIGNALS["subscribed"].append((signal_alias, callback))
+        else:
+            logger.warning("Could not register signal callback for interface:%s, signal:%s", iface_name, signal_name)

--- a/halinuxcompanion/notifier.py
+++ b/halinuxcompanion/notifier.py
@@ -90,7 +90,13 @@ class Notifier:
         :param dbus: The Dbus class abstraction
         """
         # Get the interface
-        self.interface = await dbus.get_interface("org.freedesktop.Notifications")
+        interface = await dbus.get_interface("org.freedesktop.Notifications")
+
+        if interface is None:
+            logger.warning("Could not find org.freedesktop.Notifications interface, disabling notification support.")
+            return
+
+        self.interface = interface
         # Setup dbus callbacks
         self.interface.on_action_invoked(self.on_action)
         self.interface.on_notification_closed(self.on_close)

--- a/halinuxcompanion/sensors/status.py
+++ b/halinuxcompanion/sensors/status.py
@@ -59,4 +59,5 @@ Status.signals = {
     "system.login_on_prepare_for_sleep": on_prepare_for_sleep,
     "system.login_on_prepare_for_shutdown": on_prepare_for_shutdown,
     "session.screensaver_on_active_changed": screensaver_on_active_changed,
+    "session.gnome_screensaver_on_active_changed": screensaver_on_active_changed,
 }


### PR DESCRIPTION
org.freedesktop.ScreenSaver.ActiveChanged seems to be a KDE invention[1], while org.gnome.ScreenSaver.ActiveChanged is the API used by other implementations [2].

Tested on Fedora 37 with Gnome 43.2 on Wayland

[1] https://people.freedesktop.org/~hadess/idle-inhibition-spec/re01.html
[2] https://gitlab.gnome.org/GNOME/gnome-shell/-/blob/main/data/dbus-interfaces/org.gnome.ScreenSaver.xml