### PR TITLE
Fix uptime sensor state class

### DIFF
--- a/halinuxcompanion/sensors/uptime.py
+++ b/halinuxcompanion/sensors/uptime.py
@@ -5,7 +5,7 @@ from datetime import datetime, timezone
 Uptime = Sensor()
 Uptime.config_name = "uptime"
 Uptime.device_class = "timestamp"
-Uptime.state_class = "measurement"
+Uptime.state_class = ""
 Uptime.icon = "mdi:clock"
 Uptime.name = "Uptime"
 Uptime.state = 0


### PR DESCRIPTION
With this change, no warnings are seen in the Home Assistant log any more.

Fixes #23.