### PR TITLE
Change default `idle` attribute to `false`

### DIFF
--- a/halinuxcompanion/sensors/status.py
+++ b/halinuxcompanion/sensors/status.py
@@ -16,7 +16,7 @@ Status.unique_id = "status"
 Status.icon = "mdi:cpu-64-bit"
 
 Status.state = True
-Status.attributes = {"reason": "power_on", "idle": "unknown"}
+Status.attributes = {"reason": "power_on", "idle": "false"}
 
 IDLE = {True: {"idle": "true"}, False: {"idle": "false"}}
 SLEEP = {True: {"reason": "sleep"}, False: {"reason": "wake"}}


### PR DESCRIPTION
Right now when the companion app is started, the status sensor will have the `idle` attribute set to `unknown` until the computer has been put in suspend or is shut down. I'm suggesting that we change the default value to `false` instead, because unless I'm mistaken, it should be safe to assume that the computer is _not_ idle when the companion app starts. Having only two valid states of the `idle` attribute simplifies using it in e.g. automations.