### PR TITLE
Fix: convert the notification icon to string first

### DIFF
--- a/halinuxcompanion/notifier.py
+++ b/halinuxcompanion/notifier.py
@@ -316,7 +316,7 @@ class Notifier:
         id = await self.interface.call_notify(
             APP_NAME,
             notification["replace_id"],
-            notification["icon"],
+            str(notification["icon"]),
             notification["title"],
             notification["message"],
             notification["actions"],


### PR DESCRIPTION
Always convert notification icon to `str`. This should work when the input is a `str` already, but also when it's `pathlib.PosixPath`. Fixes #35.