### PR TITLE
Fix link for long-lived access token

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ Python 3.10+ and the related `dev` dependencies (usually `python3-dev` or `pytho
 
 ### Instructions
 
-1. [Get a long-lived access token from your Home Assistant user](https://www.atomicha.com/home-assistant-how-to-generate-long-lived-access-token-part-1/)
+1. [Get a long-lived access token from your Home Assistant user](https://www.home-assistant.io/docs/authentication/#your-account-profile)
 1. Clone this repository.
 1. Create a Python virtual environment and install all the requirements:
 


### PR DESCRIPTION
Hi, I also noticed that the link pointing to the long-lived access token in the readme was dead. I updated it to point to the official HA documentation. They don't have a dedicated page about these tokens, but they're mentioned in the referenced docs.