### PR TITLE
Update requirements to work with python 3.13

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -6,5 +6,5 @@ pytest-asyncio==0.21.1
 pytest-cov==4.1.0
 coverage==7.3.2
 tox==4.11.3
-pydantic==2.4.2
-greenlet==3.0.1
+pydantic==2.10.4
+greenlet==3.1.1


### PR DESCRIPTION
`pydantic` and `greenlet` don't work with python 3.13.x in their previous versions. The updated requirements allow building the package on python 3.13. I've only tested the notification function, though.