### PR TITLE
Add idle_time sensor

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ Python 3.10+ and the related `dev` dependencies (usually `python3-dev` or `pytho
    source .venv/bin/activate
    pip install -r requirements.txt
    ```
-
+1. You will also need to install `xprintidle` for the idle timer to work properly.
 1. Copy `config.example.json` to `config.json`.
 1. Modify `config.json` to match your setup and desired options.
 1. Run the application, either from:
@@ -61,6 +61,10 @@ Now in your Home Assistant you will see a new device in the **"mobile_app"** int
     "uptime": {
       "enabled": true,
       "name": "Uptime"
+    },
+    "idle_time": {
+      "enabled": true,
+      "name": "Idle Time"
     },
     "status": {
       "enabled": true,

--- a/config.example.json
+++ b/config.example.json
@@ -22,6 +22,10 @@
       "enabled": true,
       "name": "Uptime"
     },
+    "idle_time": {
+      "enabled": true,
+      "name": "Idle Time"
+    },
     "status": {
       "enabled": true,
       "name": "Status"

--- a/halinuxcompanion/__main__.py
+++ b/halinuxcompanion/__main__.py
@@ -47,7 +47,7 @@ async def main():
     Sensors:
         - Data is collected from sensors and sent to Home Assistant.
     Notifications:
-        - Sent from Home Assistant to the application via embeded webserver, this are sent to the desktop using Dbus.
+        - Sent from Home Assistant to the application via embeded webserver, these are sent to the desktop using Dbus.
         - Actions are triggered in dbus listened by the application. Some are handled locally others are handled by Home
           Assistant, events are relayed to it as expected (closed and action).
     """
@@ -71,7 +71,7 @@ async def main():
     sensors = list(filter(lambda x: x.config_name in companion.sensors, Sensor.instances))
     sensor_manager = SensorManager(api, sensors, bus)
 
-    # If the device can't be registered exit immidiately, nothing to do.
+    # If the device can't be registered exit immediately, nothing to do.
     ok, reg_data = await companion.load_or_register(api)
     if not ok:
         logger.critical("Device registration failed, exiting now")

--- a/halinuxcompanion/sensors/idle_time.py
+++ b/halinuxcompanion/sensors/idle_time.py
@@ -1,0 +1,20 @@
+from halinuxcompanion.sensor import Sensor
+from subprocess import run
+from types import MethodType
+
+IdleTime = Sensor()
+IdleTime.type = "sensor"
+IdleTime.config_name = "idle_time"
+IdleTime.unique_id = "idle_time"
+IdleTime.name = "Idle time"
+IdleTime.icon = "mdi:progress-clock"
+
+IdleTime.device_class = "duration"
+IdleTime.state_class = "total_increasing"
+IdleTime.unit_of_measurement = "min"
+IdleTime.state = 0  # initial state only
+
+def updater(self):
+    self.state = float(run(["xprintidle"], capture_output=True, text=True).stdout) / 1000 / 60
+
+IdleTime.updater = MethodType(updater, IdleTime)

--- a/halinuxcompanion/sensors/status.py
+++ b/halinuxcompanion/sensors/status.py
@@ -1,5 +1,6 @@
 from types import MethodType
 from halinuxcompanion.sensor import Sensor
+from subprocess import run
 import psutil
 import os
 
@@ -49,8 +50,8 @@ async def screensaver_on_active_changed(self, v):
 
 
 def updater(self):
-    # Updated only by signals
-    pass
+    idle_min = float(run(["xprintidle"], capture_output=True, text=True).stdout) / 1000 / 60
+    self.attributes.update(IDLE[idle_min >= 5])
 
 
 Status.updater = MethodType(updater, Status)


### PR DESCRIPTION
This uses `xprintidle` for an idleness sensor.

It wasn't straightforward for this Python n00bie here to include the idle attribute in the Status sensor, so I gave up on creating a new sensor just to indicate idleness (that attribute seems to be changing into `unknown` in-between updates?)

Nonetheless, it's easy to create a binary sensor helper in your HA instance, where you can also configure how much time you consider idleness; right now, I couldn't see an easy way to carry configurations from the JSON file onto the created sensors, so a HA helper seems better anyway.

Last but not least, I'm pretty sure there should be some guard against `xprintidle` not being present, but I also have no clue how to properly code that :grimacing: 