### PR TITLE
Add location reporting as a device_tracker

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,6 +49,15 @@ Now in your Home Assistant you will see a new device in the **"mobile_app"** int
   "computer_port": 8400,
   "refresh_interval": 15,
   "loglevel": "INFO",
+  "location": {
+    "enabled": false,
+    "desktop_id": "halinuxcompanion",
+    "distance_threshold": 30,
+    "time_threshold": 0,
+    "heartbeat": 900,
+    "max_accuracy": 500,
+    "max_age": 3600
+  },
   "sensors": {
     "cpu": {
       "enabled": true,
@@ -114,6 +123,44 @@ Now in your Home Assistant you will see a new device in the **"mobile_app"** int
 }
 ```
 
+## Location
+
+Optional, disabled unless the `location` section sets `"enabled": true`. When on,
+the application asks [GeoClue](https://gitlab.freedesktop.org/geoclue/geoclue) for
+the machine's position and posts it to Home Assistant, which creates a
+`device_tracker` entity for the device. No registration step is needed: Home
+Assistant creates the tracker from the first update.
+
+GeoClue must be running on the system bus, and `desktop_id` has to match an
+installed `.desktop` file — GeoClue's agent authorizes clients by that id, and an
+unknown one leaves the client started but never receiving a fix.
+
+**How well this works depends entirely on what the machine can position with.** A
+device with a GNSS receiver (a Linux phone, or a laptop with a WWAN module that
+exposes GPS) gets fixes accurate to a few metres. A typical desktop or laptop has
+no GNSS at all, so GeoClue falls back to a wifi-based lookup, which is usually
+accurate to tens or hundreds of metres and depends on the surrounding access
+points being present in the database it queries. On a machine that never moves,
+that may still be all you need for a home/away zone; it is not a substitute for a
+phone's tracker, and it can be wrong by a street.
+
+| Option | Default | Meaning |
+| --- | --- | --- |
+| `enabled` | `false` | Whether to report position at all. |
+| `desktop_id` | – | Must match an installed `.desktop` file, see above. |
+| `distance_threshold` | `30` | Metres of movement before GeoClue emits an update. Larger values save power, and cost accuracy: the last reported position can be this far behind where the device actually stopped. |
+| `time_threshold` | `0` | Seconds between GeoClue updates. `0` leaves GeoClue's own default, i.e. distance drives updates. |
+| `heartbeat` | `900` | Seconds after which the current position is reported even if the device has not moved. `0` disables it. |
+| `max_accuracy` | `500` | Metres. Fixes reported as less accurate than this are ignored rather than sent. Tighten it on a device with GNSS; raise it if a wifi-positioned machine reports nothing. |
+| `max_age` | `3600` | Seconds. A fix older than this is not reported, so Home Assistant shows a stale tracker rather than a confident wrong position. `0` disables the check. |
+
+The `max_accuracy` and `max_age` checks exist because the `update_location`
+webhook carries no timestamp — Home Assistant stamps whatever arrives as current.
+Without them, a coarse or stale fix is indistinguishable from a good one, and the
+device sits confidently in the wrong place. For the same reason the heartbeat
+re-reads GeoClue instead of resending the last payload, and sends nothing at all
+when there is no usable fix.
+
 ## Technical
 
 - [Home Assistant Native App Integration](https://developers.home-assistant.io/docs/api/native-app-integration)
@@ -145,6 +192,8 @@ Now in your Home Assistant you will see a new device in the **"mobile_app"** int
   - Status: Computer status, reflects if the computer went to sleep, wakes up, shutdown, turned on. The sensor is updated right before any of these events happen by listening to dbus signals.
   - Battery Level
   - Batter State
+- Location: reports position through GeoClue as a `device_tracker`, for presence
+  and zone automations. Optional and off by default, see [Location](#location).
 - Notifications:
   - [Actionable Notifications](https://companion.home-assistant.io/docs/notifications/actionable-notifications#building-actionable-notifications) (Triggers event in Home Assistant)
       - [Local action handler using URI](https://companion.home-assistant.io/docs/notifications/actionable-notifications#uri-values): only relative style `/lovelace/myviwew` and `http(s)` uri supported so far.

--- a/config.example.json
+++ b/config.example.json
@@ -9,6 +9,15 @@
   "computer_port": 8400,
   "refresh_interval": 15,
   "loglevel": "INFO",
+  "location": {
+    "enabled": false,
+    "desktop_id": "halinuxcompanion",
+    "distance_threshold": 30,
+    "time_threshold": 0,
+    "heartbeat": 900,
+    "max_accuracy": 500,
+    "max_age": 3600
+  },
   "sensors": {
     "cpu": {
       "enabled": true,

--- a/halinuxcompanion/__main__.py
+++ b/halinuxcompanion/__main__.py
@@ -1,5 +1,6 @@
 from halinuxcompanion.api import API, Server
 from halinuxcompanion.dbus import Dbus
+from halinuxcompanion.location import Location
 from halinuxcompanion.notifier import Notifier
 from halinuxcompanion.companion import Companion
 from halinuxcompanion.sensor import Sensor, SensorManager
@@ -92,6 +93,11 @@ async def main():
         notifier = Notifier()
         await notifier.init(bus, api, server, companion)
         await server.start()
+
+    # Location reporting, creates a device_tracker in Home Assistant
+    location = Location(api, companion)
+    if await location.init():
+        asyncio.create_task(location.heartbeat_task())
 
     interval = companion.refresh_interval
     # Loop forever updating sensors.

--- a/halinuxcompanion/companion.py
+++ b/halinuxcompanion/companion.py
@@ -46,6 +46,19 @@ class SensorConfig(BaseModel):
     name: str
 
 
+class LocationConfig(BaseModel):
+    enabled: bool
+    desktop_id: str
+    # Defaulted rather than merely Optional: pydantic treats Optional without
+    # a default as required-but-nullable, which would force every tuning knob
+    # to be spelled out in the config to enable location at all.
+    distance_threshold: Optional[int] = None
+    time_threshold: Optional[int] = None
+    heartbeat: Optional[int] = None
+    max_accuracy: Optional[int] = None
+    max_age: Optional[int] = None
+
+
 class CompanionConfig(BaseModel):
     ha_url: str
     ha_token: str
@@ -58,6 +71,9 @@ class CompanionConfig(BaseModel):
     refresh_interval: Optional[int]
     sensors: Dict[str, SensorConfig]
     services: Optional[ServicesConfig]
+    # Defaulted so configuration files written before location reporting
+    # existed keep validating, since the section is entirely optional.
+    location: Optional[LocationConfig] = None
 
 
 logger = logging.getLogger("halinuxcompanion")
@@ -88,6 +104,20 @@ class Companion:
     refresh_interval: int = 15
     computer_ip: str = ""
     computer_port: int = 8400
+    location_enabled: bool = False
+    location_desktop_id: str = ""
+    # Every emitted fix can be this far behind where the device actually
+    # stopped, since GeoClue stays quiet until the threshold is crossed.
+    location_distance_threshold: int = 30
+    # 0 leaves GeoClue's own default, i.e. distance drives the updates.
+    location_time_threshold: int = 0
+    location_heartbeat: int = 900
+    # Rejects cell-tower-grade fixes (kilometres) while accepting the wifi
+    # lookups a desktop without GNSS relies on, which are usually tens to a
+    # couple hundred metres. Devices with a real GNSS receiver can afford to
+    # set this far tighter.
+    location_max_accuracy: int = 500
+    location_max_age: int = 3600
     ha_url: str = "http://localhost:8123"
     ha_token: str
     url_program: str = ""
@@ -117,6 +147,20 @@ class Companion:
             if config.refresh_interval
             else self.refresh_interval
         )
+
+        if config.location:
+            self.location_enabled = config.location.enabled
+            self.location_desktop_id = config.location.desktop_id
+            if config.location.distance_threshold is not None:
+                self.location_distance_threshold = config.location.distance_threshold
+            if config.location.time_threshold is not None:
+                self.location_time_threshold = config.location.time_threshold
+            if config.location.heartbeat is not None:
+                self.location_heartbeat = config.location.heartbeat
+            if config.location.max_accuracy is not None:
+                self.location_max_accuracy = config.location.max_accuracy
+            if config.location.max_age is not None:
+                self.location_max_age = config.location.max_age
 
         from halinuxcompanion.sensors import __all__ as all_sensors
 

--- a/halinuxcompanion/location.py
+++ b/halinuxcompanion/location.py
@@ -1,0 +1,227 @@
+from halinuxcompanion.api import API
+from halinuxcompanion.companion import Companion
+
+from dbus_next.aio import MessageBus, ProxyInterface
+from dbus_next import BusType
+from aiohttp import ClientError
+from typing import NamedTuple, Optional
+import asyncio
+import json
+import logging
+import time
+
+logger = logging.getLogger(__name__)
+
+GEOCLUE_BUS = "org.freedesktop.GeoClue2"
+GEOCLUE_MANAGER_PATH = "/org/freedesktop/GeoClue2/Manager"
+GEOCLUE_MANAGER_IFACE = "org.freedesktop.GeoClue2.Manager"
+GEOCLUE_CLIENT_IFACE = "org.freedesktop.GeoClue2.Client"
+GEOCLUE_LOCATION_IFACE = "org.freedesktop.GeoClue2.Location"
+
+# GClueAccuracyLevel. EXACT is the only level that engages a GNSS source; the
+# lower levels rely on wifi/cell lookups which are unavailable in some regions,
+# in which case GeoClue reports no location at all rather than a coarse one.
+ACCURACY_EXACT = 8
+
+# GeoClue reports this path when the client has no fix at all.
+NO_LOCATION = "/"
+
+
+class Reading(NamedTuple):
+    """A fix as read from GeoClue, with the age needed to judge it."""
+
+    payload: dict
+    accuracy: float
+    # Epoch seconds the source took the fix, 0.0 when GeoClue reports none.
+    fix_time: float
+
+
+class Location:
+    """Reports device position to Home Assistant as a device_tracker.
+
+    Home Assistant creates the device_tracker entity from the first
+    update_location webhook, so no registration step is needed.
+    """
+
+    api: API
+    bus: MessageBus
+    client: ProxyInterface
+    enabled: bool
+    desktop_id: str
+    distance_threshold: int
+    time_threshold: int
+    heartbeat: int
+    max_accuracy: int
+    max_age: int
+    last_sent: float
+
+    def __init__(self, api: API, companion: Companion) -> None:
+        self.api = api
+        self.enabled = companion.location_enabled
+        self.desktop_id = companion.location_desktop_id
+        self.distance_threshold = companion.location_distance_threshold
+        self.time_threshold = companion.location_time_threshold
+        self.heartbeat = companion.location_heartbeat
+        self.max_accuracy = companion.location_max_accuracy
+        self.max_age = companion.location_max_age
+        self.last_sent = 0.0
+
+    async def init(self) -> bool:
+        """Create a GeoClue client and start receiving position updates."""
+        if not self.enabled:
+            return False
+
+        try:
+            self.bus = await MessageBus(bus_type=BusType.SYSTEM).connect()
+            introspection = await self.bus.introspect(GEOCLUE_BUS, GEOCLUE_MANAGER_PATH)
+            manager = self.bus.get_proxy_object(GEOCLUE_BUS, GEOCLUE_MANAGER_PATH, introspection)
+            manager_iface = manager.get_interface(GEOCLUE_MANAGER_IFACE)
+            client_path = await manager_iface.call_get_client()
+
+            introspection = await self.bus.introspect(GEOCLUE_BUS, client_path)
+            client = self.bus.get_proxy_object(GEOCLUE_BUS, client_path, introspection)
+            self.client = client.get_interface(GEOCLUE_CLIENT_IFACE)
+
+            # The agent authorizes by desktop id, so it has to match an installed
+            # .desktop file, otherwise the client starts but never receives a fix.
+            await self.client.set_desktop_id(self.desktop_id)
+            await self.client.set_requested_accuracy_level(ACCURACY_EXACT)
+            await self.client.set_distance_threshold(self.distance_threshold)
+            if self.time_threshold > 0:
+                await self.client.set_time_threshold(self.time_threshold)
+
+            self.client.on_location_updated(self.on_location_updated)
+            await self.client.call_start()
+        except Exception as e:
+            logger.error("Location reporting unavailable, is geoclue running? %s", e)
+            return False
+
+        logger.info(
+            "Location reporting started, desktop_id:%s distance_threshold:%sm "
+            "time_threshold:%ss heartbeat:%ss max_accuracy:%sm max_age:%ss",
+            self.desktop_id, self.distance_threshold, self.time_threshold,
+            self.heartbeat, self.max_accuracy, self.max_age)
+        return True
+
+    def on_location_updated(self, old_path: str, new_path: str) -> None:
+        """GeoClue signal handler, schedules the update since it cannot await."""
+        asyncio.create_task(self.handle_location(new_path))
+
+    async def handle_location(self, path: str) -> None:
+        reading = await self.read_location(path)
+        if reading is not None and self.usable(reading):
+            await self.send(reading.payload)
+
+    async def read_location(self, path: str) -> Optional[Reading]:
+        """Read a GeoClue location object, or None if it cannot be read."""
+        try:
+            introspection = await self.bus.introspect(GEOCLUE_BUS, path)
+            obj = self.bus.get_proxy_object(GEOCLUE_BUS, path, introspection)
+            location = obj.get_interface(GEOCLUE_LOCATION_IFACE)
+
+            accuracy = await location.get_accuracy()
+            payload = {
+                "gps": [await location.get_latitude(), await location.get_longitude()],
+                "gps_accuracy": round(accuracy),
+            }
+
+            # GeoClue reports these as 0.0 when the source cannot determine them,
+            # and Home Assistant would show that as a real value.
+            altitude = await location.get_altitude()
+            if altitude:
+                payload["altitude"] = round(altitude)
+            speed = await location.get_speed()
+            if speed and speed > 0:
+                payload["speed"] = round(speed)
+            heading = await location.get_heading()
+            if heading and heading > 0:
+                payload["course"] = round(heading)
+
+            # Timestamp is (seconds, microseconds) since the epoch, describing
+            # when the source took the fix rather than when it was read here.
+            # Sources that do not supply one report zero.
+            timestamp = await location.get_timestamp()
+            fix_time = float(timestamp[0]) if timestamp else 0.0
+        except Exception as e:
+            logger.error("Failed to read location from geoclue: %s", e)
+            return None
+
+        return Reading(payload, accuracy, fix_time)
+
+    def usable(self, reading: Reading) -> bool:
+        """Whether a fix is worth asserting as the device's position.
+
+        Home Assistant plots whatever point it is given, so a fix that is
+        merely the best GeoClue could manage still has to be filtered here or
+        it becomes the device's reported position.
+        """
+        # Zero means the source did not state an accuracy, which is not the
+        # same as a perfect fix, and there is nothing to judge it by.
+        if self.max_accuracy > 0 and reading.accuracy > self.max_accuracy:
+            logger.info(
+                "Ignoring location, accuracy %sm exceeds max_accuracy %sm",
+                round(reading.accuracy), self.max_accuracy)
+            return False
+
+        age = time.time() - reading.fix_time if reading.fix_time else 0.0
+        if self.max_age > 0 and age > self.max_age:
+            logger.info(
+                "Ignoring location, fix is %ss old, over max_age %ss",
+                round(age), self.max_age)
+            return False
+
+        return True
+
+    async def send(self, payload: dict) -> None:
+        data = json.dumps({"type": "update_location", "data": payload})
+        try:
+            await self.api.webhook_post("update_location", data=data)
+            self.last_sent = time.monotonic()
+            logger.info("Location update sent, accuracy:%sm", payload["gps_accuracy"])
+        except ClientError as e:
+            logger.error("Failed to send location update: %s", e)
+
+    async def heartbeat_task(self) -> None:
+        """Report the current position when nothing has moved.
+
+        DistanceThreshold means a stationary device stops emitting updates
+        entirely, which is exactly when a lost or stolen device still needs to
+        report where it is.
+
+        This re-reads GeoClue rather than resending the last payload. The
+        threshold suppresses updates until the device has moved that far, so
+        the last emitted fix can be a threshold's worth of distance behind
+        where it actually came to rest, and replaying it would keep asserting
+        that stale point — the webhook carries no timestamp, so Home Assistant
+        stamps every arrival as current no matter how old the fix is. Reading
+        the client's current location converges on the resting position
+        instead, and costs nothing extra: GeoClue serves the last fix its
+        source produced, it does not power up a receiver to answer.
+        """
+        if not self.enabled or self.heartbeat <= 0:
+            return
+
+        while True:
+            await asyncio.sleep(self.heartbeat)
+            if time.monotonic() - self.last_sent < self.heartbeat:
+                continue
+
+            path = await self.current_location_path()
+            if path is None:
+                continue
+            reading = await self.read_location(path)
+            if reading is not None and self.usable(reading):
+                await self.send(reading.payload)
+
+    async def current_location_path(self) -> Optional[str]:
+        """The client's current fix, or None when it has none to give."""
+        try:
+            path = await self.client.get_location()
+        except Exception as e:
+            logger.error("Failed to read current location from geoclue: %s", e)
+            return None
+
+        if not path or path == NO_LOCATION:
+            logger.info("No location available from geoclue yet")
+            return None
+        return path

--- a/halinuxcompanion/test_location.py
+++ b/halinuxcompanion/test_location.py
@@ -1,0 +1,244 @@
+from halinuxcompanion.companion import Companion
+from halinuxcompanion.location import Location, Reading
+import asyncio
+import json
+import time
+import types
+
+
+def run(coro):
+    """Drive a coroutine to completion.
+
+    The suite has no async plugin configured in tox.ini, so the tests stay
+    synchronous and drive the event loop themselves.
+    """
+    return asyncio.new_event_loop().run_until_complete(coro)
+
+
+def companion(**overrides) -> types.SimpleNamespace:
+    """A stand in for Companion carrying only what Location reads."""
+    config = {
+        "location_enabled": True,
+        "location_desktop_id": "halinuxcompanion",
+        "location_distance_threshold": 30,
+        "location_time_threshold": 0,
+        "location_heartbeat": 900,
+        "location_max_accuracy": 500,
+        "location_max_age": 3600,
+    }
+    config.update(overrides)
+    return types.SimpleNamespace(**config)
+
+
+def make(**overrides) -> Location:
+    return Location(api=None, companion=companion(**overrides))
+
+
+def reading(accuracy: float = 10.0, age: float = 0.0, lat: float = 41.0, lon: float = -73.0) -> Reading:
+    return Reading(
+        payload={"gps": [lat, lon], "gps_accuracy": round(accuracy)},
+        accuracy=accuracy,
+        fix_time=time.time() - age,
+    )
+
+
+def collect(location: Location) -> list:
+    """Capture what would be posted to Home Assistant."""
+    sent: list = []
+
+    async def send(payload):
+        sent.append(payload)
+        location.last_sent = time.monotonic()
+
+    location.send = send
+    return sent
+
+
+def base_config() -> dict:
+    with open("tests/config.json") as f:
+        return json.load(f)
+
+
+def test_config_without_a_location_section_is_still_valid():
+    # Configuration files predate this feature, so its absence has to keep
+    # working rather than failing validation at startup.
+    config = base_config()
+    config.pop("location", None)
+    companion = Companion(config)
+    assert companion.location_enabled is False
+
+
+def test_location_section_only_needs_to_be_enabled():
+    config = base_config()
+    config["location"] = {"enabled": True, "desktop_id": "halinuxcompanion"}
+    companion = Companion(config)
+
+    assert companion.location_enabled is True
+    assert companion.location_desktop_id == "halinuxcompanion"
+    assert companion.location_distance_threshold == 30
+    assert companion.location_time_threshold == 0
+    assert companion.location_heartbeat == 900
+    assert companion.location_max_accuracy == 500
+    assert companion.location_max_age == 3600
+
+
+def test_location_section_overrides_the_defaults():
+    config = base_config()
+    config["location"] = {
+        "enabled": True,
+        "desktop_id": "halinuxcompanion",
+        "distance_threshold": 100,
+        "time_threshold": 60,
+        "heartbeat": 300,
+        "max_accuracy": 50,
+        "max_age": 120,
+    }
+    companion = Companion(config)
+
+    assert companion.location_distance_threshold == 100
+    assert companion.location_time_threshold == 60
+    assert companion.location_heartbeat == 300
+    assert companion.location_max_accuracy == 50
+    assert companion.location_max_age == 120
+
+
+def test_accuracy_within_the_ceiling_is_reported():
+    assert make().usable(reading(accuracy=12.0))
+    assert make().usable(reading(accuracy=500.0))
+
+
+def test_accuracy_beyond_the_ceiling_is_ignored():
+    # Cell tower derived fixes land here, and would otherwise be reported as
+    # the device's position with no indication they are a guess.
+    assert not make().usable(reading(accuracy=1500.0))
+
+
+def test_accuracy_ceiling_can_be_disabled():
+    assert make(location_max_accuracy=0).usable(reading(accuracy=9999.0))
+
+
+def test_unstated_accuracy_is_not_treated_as_perfect_or_rejected():
+    # GeoClue reports 0.0 when the source did not say, which is not a claim of
+    # perfect accuracy, but there is nothing to reject it by either.
+    assert make().usable(reading(accuracy=0.0))
+
+
+def test_fresh_fix_is_reported():
+    assert make().usable(reading(age=5))
+
+
+def test_fix_older_than_max_age_is_ignored():
+    assert not make().usable(reading(age=7200))
+
+
+def test_age_check_can_be_disabled():
+    assert make(location_max_age=0).usable(reading(age=7200))
+
+
+def test_fix_without_a_timestamp_is_not_treated_as_stale():
+    ageless = Reading(payload={"gps": [1, 2], "gps_accuracy": 10}, accuracy=10.0, fix_time=0.0)
+    assert make().usable(ageless)
+
+
+def test_heartbeat_reports_the_current_position_not_the_last_one_sent():
+    location = make(location_heartbeat=0.01)
+    sent = collect(location)
+    current = reading(lat=41.001, lon=-73.001)
+    stale = reading(lat=41.0, lon=-73.0)
+
+    async def current_location_path():
+        return "/org/freedesktop/GeoClue2/Location/1"
+
+    async def read_location(path):
+        return current
+
+    location.current_location_path = current_location_path
+    location.read_location = read_location
+
+    async def beat_once():
+        task = asyncio.ensure_future(location.heartbeat_task())
+        await asyncio.sleep(0.15)
+        task.cancel()
+
+    run(beat_once())
+
+    assert sent, "heartbeat reported nothing"
+    assert sent[0]["gps"] == current.payload["gps"]
+    assert all(payload["gps"] != stale.payload["gps"] for payload in sent)
+
+
+def test_heartbeat_reports_nothing_when_there_is_no_fix():
+    location = make(location_heartbeat=0.01)
+    sent = collect(location)
+
+    async def current_location_path():
+        return None
+
+    location.current_location_path = current_location_path
+
+    async def beat_once():
+        task = asyncio.ensure_future(location.heartbeat_task())
+        await asyncio.sleep(0.1)
+        task.cancel()
+
+    run(beat_once())
+
+    # Better a tracker that goes stale than one confidently in the wrong place.
+    assert sent == []
+
+
+def test_heartbeat_does_not_report_an_unusable_fix():
+    location = make(location_heartbeat=0.01)
+    sent = collect(location)
+
+    async def current_location_path():
+        return "/org/freedesktop/GeoClue2/Location/1"
+
+    async def read_location(path):
+        return reading(accuracy=3000.0)
+
+    location.current_location_path = current_location_path
+    location.read_location = read_location
+
+    async def beat_once():
+        task = asyncio.ensure_future(location.heartbeat_task())
+        await asyncio.sleep(0.1)
+        task.cancel()
+
+    run(beat_once())
+
+    assert sent == []
+
+
+def test_heartbeat_defers_to_a_recent_update():
+    location = make(location_heartbeat=0.05)
+    sent = collect(location)
+
+    async def read_location(path):
+        raise AssertionError("heartbeat should not have read a location")
+
+    async def current_location_path():
+        return "/org/freedesktop/GeoClue2/Location/1"
+
+    location.current_location_path = current_location_path
+    location.read_location = read_location
+    location.last_sent = time.monotonic()
+
+    async def beat_once():
+        task = asyncio.ensure_future(location.heartbeat_task())
+        await asyncio.sleep(0.07)
+        task.cancel()
+
+    run(beat_once())
+
+    assert sent == []
+
+
+def test_heartbeat_can_be_disabled():
+    location = make(location_heartbeat=0)
+    run(asyncio.wait_for(location.heartbeat_task(), timeout=1))
+
+
+def test_disabled_location_does_not_start_a_heartbeat():
+    location = make(location_enabled=False)
+    run(asyncio.wait_for(location.heartbeat_task(), timeout=1))


### PR DESCRIPTION
Adds optional location reporting: a GeoClue2 client that posts fixes to the existing `update_location` webhook, which makes Home Assistant create a `device_tracker` for the machine so it can be used for presence and zones. This is the "roaming laptops" direction from the README's to-do list, though it does not attempt the remote/local instance part.

- Off unless a `location` section sets `"enabled": true`.
- No new dependencies — `dbus_next` is already required for notifications.
- Existing configuration files keep working: the section and every option in it are defaulted, so a config written before this change still validates.

### How well it works depends on the machine

Worth being upfront, since the answer is very different per device:

- A machine with a GNSS receiver (a Linux phone, or a laptop with a WWAN module exposing GPS) gets fixes accurate to a few metres.
- A typical desktop or laptop has no GNSS, so GeoClue falls back to a wifi lookup — usually tens to hundreds of metres, and dependent on the surrounding access points being in the database it queries. For a machine that never moves that may be enough for a home/away zone, but it can be wrong by a street, and it is not a replacement for a phone's tracker.

`max_accuracy` defaults to 500m for that reason: it rejects cell-tower-grade fixes without discarding the wifi positioning a desktop depends on. Devices with GNSS can set it far tighter.

### Design notes

Two things that are less obvious than they look, both documented in the commit and the README:

- **The heartbeat re-reads GeoClue rather than resending the last payload.** `update_location` carries no timestamp, so Home Assistant stamps whatever arrives as current. Replaying a cached fix therefore asserts a stale position indefinitely while looking freshly updated. Re-reading costs nothing, since GeoClue serves the last fix its source produced rather than powering up a receiver to answer. It exists at all because `DistanceThreshold` means a stationary device stops emitting entirely, which is when a lost device most needs to report.
- **Fixes are dropped when they are worse than `max_accuracy` or older than `max_age`, and nothing is sent when there is no usable fix.** `RequestedAccuracyLevel = EXACT` is only a hint about which source GeoClue may use, not a floor on what it delivers, so coarse fixes still arrive and would otherwise be plotted as the device's position. A tracker that goes stale is honest; one that is confidently in the wrong place is not.

Similarly, `distance_threshold` defaults to a fairly tight 30m because the last emitted fix can be a threshold's worth of distance behind where the device actually came to rest.

### Testing

- Running on a FuriPhone FLX1s+ (FuriOS/Phosh, geoclue 2.7.1 with the hybris GNSS source) reporting to Home Assistant 2026.7 over HTTPS, currently producing 3m fixes.
- `halinuxcompanion/test_location.py` adds 15 tests covering config defaults and the reporting rules, including that the heartbeat reports the current fix rather than a stale one. They drive the event loop directly instead of using a `pytest-asyncio` marker, since that plugin is in `requirements.txt` but not in the tox environment, where a marked test would silently skip.
- Full suite passes (21 tests), and `pycodestyle --max-line-length=120` is clean across the package.

Happy to adjust any of the defaults, or to gate the feature differently, if you would rather it were shaped another way.

---

Developed with AI assistance (Claude); the commits carry a `Co-Authored-By` trailer to that effect. Everything above has been reviewed and tested on real hardware.
